### PR TITLE
Add verbose mode to set the log level to DEBUG

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deploy-agent (1.2.1)
+    deploy-agent (1.2.2)
       nio4r (= 2.1.0)
       rb-readline (= 0.5.5)
       timers (= 4.1.2)
@@ -23,4 +23,4 @@ DEPENDENCIES
   deploy-agent!
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deploy-agent (1.2.2)
+    deploy-agent (1.2.3)
       nio4r (= 2.1.0)
       rb-readline (= 0.5.5)
       timers (= 4.1.2)

--- a/deploy-agent.gemspec
+++ b/deploy-agent.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'deploy-agent'
-  s.version     = '1.2.2'
+  s.version     = '1.2.3'
   s.summary     = "The DeployHQ Agent"
   s.description = "This gem allows you to configure a secure proxy through which DeployHQ can forward connections"
   s.authors     = ["aTech Media"]

--- a/deploy-agent.gemspec
+++ b/deploy-agent.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name        = 'deploy-agent'
-  s.version     = '1.2.1'
-  s.summary     = "The Deploy agent"
-  s.description = "This gem allows you to configure a secure proxy through which Deploy can forward connections"
+  s.version     = '1.2.2'
+  s.summary     = "The DeployHQ Agent"
+  s.description = "This gem allows you to configure a secure proxy through which DeployHQ can forward connections"
   s.authors     = ["aTech Media"]
   s.email       = ["support@deployhq.com"]
   s.files       = Dir.glob("{lib,bin}/**/*")

--- a/lib/deploy_agent.rb
+++ b/lib/deploy_agent.rb
@@ -3,6 +3,7 @@ require 'deploy_agent/server_connection'
 require 'deploy_agent/destination_connection'
 require 'deploy_agent/cli'
 require 'deploy_agent/agent'
+require 'rubygems'
 
 module DeployAgent
   CONFIG_PATH      = File.expand_path('~/.deploy')
@@ -12,6 +13,7 @@ module DeployAgent
   LOG_PATH         = File.expand_path('~/.deploy/agent.log')
   ACCESS_PATH      = File.expand_path('~/.deploy/agent.access')
   CA_PATH          = File.expand_path('../../ca.crt', __FILE__)
+  VERSION          = Gem::Specification::load("deploy-agent.gemspec").version
 
   def self.allowed_destinations
       destinations = File.read(ACCESS_PATH)

--- a/lib/deploy_agent.rb
+++ b/lib/deploy_agent.rb
@@ -3,7 +3,6 @@ require 'deploy_agent/server_connection'
 require 'deploy_agent/destination_connection'
 require 'deploy_agent/cli'
 require 'deploy_agent/agent'
-require 'rubygems'
 
 module DeployAgent
   CONFIG_PATH      = File.expand_path('~/.deploy')
@@ -13,7 +12,6 @@ module DeployAgent
   LOG_PATH         = File.expand_path('~/.deploy/agent.log')
   ACCESS_PATH      = File.expand_path('~/.deploy/agent.access')
   CA_PATH          = File.expand_path('../../ca.crt', __FILE__)
-  VERSION          = Gem::Specification::load("deploy-agent.gemspec").version
 
   def self.allowed_destinations
       destinations = File.read(ACCESS_PATH)

--- a/lib/deploy_agent/agent.rb
+++ b/lib/deploy_agent/agent.rb
@@ -6,6 +6,9 @@ require 'logger'
 
 module DeployAgent
   class Agent
+    def initialize(options = {})
+      @options = options
+    end
 
     def run
       nio_selector = NIO::Selector.new
@@ -30,7 +33,7 @@ module DeployAgent
       @logger ||= begin
         if $background
           logger = Logger.new(LOG_PATH, 5, 10240)
-          logger.level = Logger::INFO
+          logger.level = @options[:verbose] ? Logger::DEBUG : Logger::INFO
           logger
         else
           Logger.new(STDOUT)
@@ -38,5 +41,8 @@ module DeployAgent
       end
     end
 
+    private
+
+    attr_reader :options
   end
 end

--- a/lib/deploy_agent/agent.rb
+++ b/lib/deploy_agent/agent.rb
@@ -27,6 +27,11 @@ module DeployAgent
       end
     rescue ServerConnection::ServerDisconnected
       retry
+    rescue Interrupt, SignalException => e
+      logger.info("Stopping")
+    rescue Exception => e
+      logger.debug("#{e.class}: #{e.message}")
+      raise e
     end
 
     def logger

--- a/lib/deploy_agent/agent.rb
+++ b/lib/deploy_agent/agent.rb
@@ -33,11 +33,11 @@ module DeployAgent
       @logger ||= begin
         if $background
           logger = Logger.new(LOG_PATH, 5, 10240)
-          logger.level = @options[:verbose] ? Logger::DEBUG : Logger::INFO
-          logger
         else
-          Logger.new(STDOUT)
+          logger = Logger.new(STDOUT)
         end
+        logger.level = @options[:verbose] ? Logger::DEBUG : Logger::INFO
+        logger
       end
     end
 

--- a/lib/deploy_agent/cli.rb
+++ b/lib/deploy_agent/cli.rb
@@ -89,6 +89,10 @@ module DeployAgent
       puts "To edit the list of allowed servers, please modify " + ACCESS_PATH
     end
 
+    def version
+      puts "You are running version #{VERSION} of the DeployHQ Agent"
+    end
+
     private
 
     def ensure_configured

--- a/lib/deploy_agent/cli.rb
+++ b/lib/deploy_agent/cli.rb
@@ -1,10 +1,20 @@
 require 'ipaddr'
+require 'optparse'
 
 module DeployAgent
   class CLI
 
     def dispatch(arguments)
       methods = self.public_methods(false).delete_if { |n| n == :dispatch }.sort
+
+      @options = {}
+
+      OptionParser.new do |opts|
+        opts.on('-v', '--verbose', 'Log extra debug information') do
+          @options[:verbose] = true
+        end
+      end.parse!
+
       if arguments[0] && methods.include?(arguments[0].to_sym)
         public_send(arguments[0])
       else
@@ -62,7 +72,7 @@ module DeployAgent
 
     def run
       ensure_configured
-      Agent.new.run
+      Agent.new(@options).run
     end
 
     def accesslist

--- a/lib/deploy_agent/cli.rb
+++ b/lib/deploy_agent/cli.rb
@@ -90,7 +90,7 @@ module DeployAgent
     end
 
     def version
-      puts "You are running version #{VERSION} of the DeployHQ Agent"
+      puts "You are running version 1.2.3 of the DeployHQ Agent"
     end
 
     private

--- a/lib/deploy_agent/destination_connection.rb
+++ b/lib/deploy_agent/destination_connection.rb
@@ -79,7 +79,7 @@ module DeployAgent
         # Nothing more to send, wait for inbound data only
         @nio_monitor.interests = :r
       end
-    rescue Errno::ECONNRESET
+    rescue Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ENETRESET
       # The backend has closed the connection. Inform the Deploy server.
       @server_connection.send_connection_close(@id)
       # Ensure everything is tidied up
@@ -91,7 +91,7 @@ module DeployAgent
       data = @tcp_socket.readpartial(10240)
       @agent.logger.debug "[#{@id}] #{data.bytesize} bytes received from destination"
       @server_connection.send_data(@id, data)
-    rescue EOFError, Errno::ECONNRESET
+    rescue EOFError, Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ENETRESET
       @agent.logger.info "[#{@id}] Destination closed connection"
       # The backend has closed the connection. Inform the Deploy server.
       @server_connection.send_connection_close(@id)

--- a/lib/deploy_agent/server_connection.rb
+++ b/lib/deploy_agent/server_connection.rb
@@ -151,7 +151,9 @@ module DeployAgent
 
     # Called by event loop to send all waiting packets to the Deploy server
     def tx_data
+      @agent.logger.debug('Writing to socket')
       bytes_sent = @socket.write_nonblock(@tx_buffer[0,1024])
+      @agent.logger.debug('Writing to socket completed')
       # Send as much data as possible
       if bytes_sent >= @tx_buffer.bytesize
         @tx_buffer = String.new.force_encoding('BINARY')

--- a/lib/deploy_agent/server_connection.rb
+++ b/lib/deploy_agent/server_connection.rb
@@ -113,7 +113,7 @@ module DeployAgent
           close
         end
       end
-    rescue EOFError, Errno::ECONNRESET
+    rescue EOFError, Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ENETRESET
       close
     end
 
@@ -161,7 +161,7 @@ module DeployAgent
         # the remaining data in the send buffer
         @tx_buffer.slice!(0, bytes_sent)
       end
-    rescue EOFError, Errno::ECONNRESET
+    rescue EOFError, Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ENETRESET
       close
     end
 


### PR DESCRIPTION
I have additionally added a new `version` method which will print the user's current version of the gem. At the moment, users need to do some weird grepping, this should make things easier for support.